### PR TITLE
added foreground intention and allow themes other than default to be used

### DIFF
--- a/swap-md-paint.js
+++ b/swap-md-paint.js
@@ -25,7 +25,8 @@
       primary:'primary',
       accent:'accent',
       warn:'warn',
-      background:'background'
+      background:'background',
+      foreground:'primary'
     };
     var hues = {
       'default':'default',
@@ -34,13 +35,17 @@
       'hue-3':'hue-3'
     };
 
+    var contrast = false
+
     // Do our best to parse out the attributes
     angular.forEach(input.split(' '), function(value, key) {
-      if (0 === key && 'default' === value) {
+      if (0 === key) {
         themeName = value;
       } else
       if (intentions[value]) {
-        intentionName = value;
+        if(value === 'foreground')
+          contrast = true
+        intentionName = intentions[value];
       } else if (hues[value]) {
         hueName = value;
       } else if (shades[value]) {
@@ -55,7 +60,8 @@
           hueKey = intention.hues[hueName];
         }
         if ((hue = themeProvider._PALETTES[intention.name][hueKey]) ) {
-          element.css(styled,'rgb('+hue.value[0]+','+hue.value[1]+','+hue.value[2]+')');
+          var color = hue[contrast ? 'contrast' : 'value']
+          element.css(styled,'rgb('+color[0]+','+color[1]+','+color[2]+')');
           return;
         }
       }
@@ -66,7 +72,7 @@
   function reportError(errString,name,input) {
     console.error(errString,name,input);
     console.log('usage %s="[theme] intention [hue]"',name);
-    console.log('acceptable intentions : primary,accent,warn,background');
+    console.log('acceptable intentions : primary,accent,warn,background,foreground');
     console.log('acceptable hues       : default,hue-1,hue-2,hue-3');
   }
 


### PR DESCRIPTION
`<div md-swap-paint-fg='customThemeName foreground'>` will properly render the text with the contrast color given by the theme for the primary palette.

[The colors here](https://material.google.com/style/color.html#color-color-palette) will show that Red 300 has a black foreground while Red 500 has a white foreground. 
![image](https://cloud.githubusercontent.com/assets/4142480/16134217/9b5de5ec-33e1-11e6-9c47-b358283a3543.png)

This also fixes issue #1

---

For anyone else doing something remotely similar, here's how you can do it too! 

I am using [md-data-table](https://github.com/daniel-nagy/md-data-table) with this([swap-md-paint](https://github.com/sirap-group/swap-md-paint))

[Example (untested) HTML for tables](https://gist.github.com/Meshiest/75a9e63921a56f7fae562581fa4bf380)
[CSS to work with md-tables and swap-md](https://gist.github.com/Meshiest/f8e9faadea70117d295333b0404c332c)

This works by making the `tbody` background color the same as the theme primary and the `tbody` and all its childrens' colors the same as the theme primary font contrast color. The `tr` color is clear by default and tinted slightly black when selected or hovered over. 

Here are some fancy screenshots (of my use case):

![image](https://cloud.githubusercontent.com/assets/4142480/16134275/e34e3db6-33e1-11e6-9556-f47f02ec10e3.png)
![image](https://cloud.githubusercontent.com/assets/4142480/16134583/92124152-33e3-11e6-9eeb-11eceb6fe3ce.png)
